### PR TITLE
Add .gitignore to ignore common files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+# Node modules
+node_modules/
+
+# Editor backups
+*~
+*.swp
+
+# OS-specific files
+.DS_Store
+Thumbs.db
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Compiled output
+/dist/


### PR DESCRIPTION
## Summary
- add `.gitignore` to ignore Node modules, editor backup files and OS specific files

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687bd9a72160832c9c5f82c60c2715ff