### PR TITLE
Improve mobile menu interactions

### DIFF
--- a/script.js
+++ b/script.js
@@ -79,10 +79,37 @@ function initNavigation() {
 
     heroSection.addEventListener('click', () => showSection(null));
 
-    if (menuToggle) {
-        menuToggle.addEventListener('click', () => {
-            nav.classList.toggle('open');
+    const menu = nav.querySelector('ul');
+
+    function openMenu() {
+        menu.style.display = 'flex';
+        void menu.offsetWidth; // reflow for transition
+        nav.classList.add('open');
+    }
+
+    function closeMenu() {
+        if (!nav.classList.contains('open')) return;
+        nav.classList.add('closing');
+        nav.classList.remove('open');
+        menu.addEventListener('transitionend', function handler(e) {
+            if (e.target === menu) {
+                menu.style.display = 'none';
+                nav.classList.remove('closing');
+                menu.removeEventListener('transitionend', handler);
+            }
         });
+    }
+
+    function toggleMenu() {
+        if (nav.classList.contains('open')) {
+            closeMenu();
+        } else {
+            openMenu();
+        }
+    }
+
+    if (menuToggle) {
+        menuToggle.addEventListener('click', toggleMenu);
     }
 
     navLinks.forEach(link => {
@@ -91,7 +118,7 @@ function initNavigation() {
             e.preventDefault();
             showSection(target);
             if (nav.classList.contains('open')) {
-                nav.classList.remove('open');
+                closeMenu();
             }
         });
     });

--- a/style.css
+++ b/style.css
@@ -257,6 +257,8 @@ main {
         border-radius: 0;
         left: 0;
         transform: none;
+        background-color: transparent; /* スマホでは黒背景を除去 */
+        box-shadow: none;
     }
 
     header nav {
@@ -266,6 +268,7 @@ main {
 
     .menu-toggle {
         display: block;
+        font-size: 2em; /* ハンバーガーメニューを少し大きく */
     }
 
     nav ul {
@@ -279,10 +282,17 @@ main {
         padding: 10px 0;
         display: none;
         margin: 0;
+        opacity: 0;
+        transition: opacity 0.3s ease;
     }
 
     nav.open ul {
         display: flex;
+        opacity: 1;
+    }
+
+    nav.closing ul {
+        opacity: 0;
     }
 
     nav ul li {


### PR DESCRIPTION
## Summary
- remove dark mobile header background
- enlarge hamburger menu
- fade menu in and out on mobile

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_687bf2941d64832cb049c30bebe4f338