### PR TITLE
Improve commission section layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,24 +65,24 @@
 
         <section id="commission" class="content-section hidden">
             <h2>Commission</h2>
-            <p>✅️ Base Menu (Full Color)</p>
+            <p class="commission-heading">✅️ Base Menu (Full Color)</p>
             <p>▶ $25 – Headshot (Icon, face only)</p>
             <p>▶ $45 – Bust-up (Upper body)</p>
             <p>▶ $65 – Halfbody (From head to hips/thighs)</p>
             <p>▶ $85 – Fullbody (Dynamic full-body pose)</p>
-            <p>✅️ Color Options</p>
+            <p class="commission-heading">✅️ Color Options</p>
             <p>▶ –15%, Monochrome<br>Lineart + grayscale shading</p>
             <p>▶ –10%, Base Color<br>Flat color + soft shading</p>
             <p>▶ Full Color = base price (standard)<br>You may request a simpler version<br>(monochrome or base color) at a lower price.</p>
-            <p>✅️ BG Menu</p>
+            <p class="commission-heading">✅️ BG Menu</p>
             <p>▶ Free (+$0) – No BG / Simple<br>Flat color background</p>
             <p>▶ +$5 – Two-color gradient (sky, water, soft lighting)</p>
             <p>▶ +$10 – Transparent BG<br>Clean-edged transparent PNG (extra export effort)</p>
             <p>▶ +$25–35 – Standard BG<br>Simple scenery: sky, grass, clouds, water, silhouettes</p>
             <p>▶ +$50–80 – Complex BG<br>Buildings, trees, reflections, lighting, depth (may be declined)</p>
-            <p>✅️ Other</p>
+            <p class="commission-heading">✅️ Other</p>
             <p>▶ $30–$50 – Animated Icon (GIF)<br>Eye blinking / small movement loop</p>
-            <p>✅️ Extras & Notes</p>
+            <p class="commission-heading">✅️ Extras & Notes</p>
             <p>▶ +$10–20 – Complex designs (wings, armor, patterns)</p>
             <p>▶ +$10 – Suggestive themes (fetish only)</p>
             <p>▼Up to 2 minor revisions after sketch approval</p>

--- a/style.css
+++ b/style.css
@@ -316,3 +316,19 @@ main {
         width: 100%;
     }
 }
+
+/* Commission Section Styles */
+#commission {
+    text-align: left;
+}
+
+#commission .commission-heading {
+    font-weight: bold;
+    color: #ffcc00;
+    font-size: 1.2em;
+    margin-top: 30px;
+}
+
+#commission h3 {
+    color: #ffcc00;
+}


### PR DESCRIPTION
## Summary
- left-align the commission section and highlight headers

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687bf5002710832c8d7787f53b8254e0