### PR TITLE
Add Militia artwork with glowing title

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,6 +86,13 @@
                         <p>This was exhibited at an exhibition in Kumamoto, Japan.</p>
                     </div>
                 </div>
+                <div class="artwork-item square" data-tags="sfw" data-title="Militia" data-desc="we need some backup for the this place">
+                    <img src="https://yueplush-artwork.netlify.app/militia_optimized.webp" alt="Militia">
+                    <div class="art-info">
+                        <h3>Militia</h3>
+                        <p>we need some backup for the this place</p>
+                    </div>
+                </div>
                 <!-- 必要に応じてさらに作品を追加 -->
             </div>
         </section>

--- a/style.css
+++ b/style.css
@@ -495,8 +495,8 @@ main {
 }
 
 .lightbox-content img {
-    max-width: 80vw;
-    max-height: 80vh;
+    max-width: 90vw;
+    max-height: 90vh;
     border-radius: 5px;
 }
 
@@ -507,8 +507,18 @@ main {
 .lightbox-text h3 {
     color: #0f0;
     margin-top: 0;
+    animation: glow 1.5s ease-in-out infinite alternate;
 }
 
 .lightbox-text p {
     margin-bottom: 0;
+}
+
+@keyframes glow {
+    from {
+        text-shadow: 0 0 5px #0f0, 0 0 10px #0f0, 0 0 20px #0f0;
+    }
+    to {
+        text-shadow: 0 0 8px #0f0, 0 0 15px #0f0, 0 0 30px #0f0;
+    }
 }


### PR DESCRIPTION
## Summary
- add "Militia" artwork entry
- enlarge lightbox image size
- make lightbox title text glow with animation

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_687c083e4230832c84dd72b944d7308c