### PR TITLE
Add grayscale hover effect for artwork thumbnails

### DIFF
--- a/style.css
+++ b/style.css
@@ -300,6 +300,13 @@ main {
     width: 100%;
     height: 200px;
     object-fit: cover;
+    filter: grayscale(100%);
+    transition: filter 0.3s ease;
+}
+
+.artwork-item.square:hover img,
+.artwork-item.square:active img {
+    filter: grayscale(0%);
 }
 
 @media (max-width: 600px) {


### PR DESCRIPTION
## Summary
- show all square artwork thumbnails in grayscale by default
- switch thumbnails to color when hovered or held

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687c10031518832c93a0189890cca230