### PR TITLE
Add desktop/tablet lightbox close on image click

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ they are adults. After confirming, subcategories such as Bubbles, Balloons,
 Pooltoy and Other become available. No suggestive artwork is shown until one of
 these subcategories is chosen.
 
-On smartphones, tapping an artwork opens a full screen view. Tapping the full
-image again closes it for easier navigation on mobile devices.
+Tapping an artwork opens it in a full screen view. Clicking or tapping the
+full image again fades it out and closes the lightbox on desktop, tablets and
+smartphones alike for consistent navigation across devices.
 
 ## License
 

--- a/script.js
+++ b/script.js
@@ -208,6 +208,8 @@ function initLightbox() {
     const title = document.getElementById('lightbox-title');
     const desc = document.getElementById('lightbox-desc');
 
+    // Detect viewport width in case different behaviour is needed in the
+    // future, though currently the lightbox acts the same on all devices.
     const isMobile = window.matchMedia('(max-width: 768px)').matches;
 
     if (!lightbox) return;
@@ -235,9 +237,9 @@ function initLightbox() {
         });
     });
 
-    if (isMobile) {
-        img.addEventListener('click', closeLightbox);
-    }
+    // Allow closing the lightbox by clicking on the image itself on all
+    // devices including desktop and tablets.
+    img.addEventListener('click', closeLightbox);
 
     lightbox.addEventListener('click', e => {
         if (e.target === lightbox) {


### PR DESCRIPTION
## Summary
- allow clicking the lightbox image to close it on all devices
- update documentation for lightbox behaviour across devices

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687c9fda785c832cbc2ab869d34d50e1