### PR TITLE
Adjust lightbox layout on tablets

### DIFF
--- a/style.css
+++ b/style.css
@@ -543,6 +543,18 @@ main {
     margin-bottom: 0;
 }
 
+@media (min-width: 601px) and (max-width: 1024px) and (orientation: portrait) {
+    .lightbox-content {
+        flex-direction: column;
+        text-align: center;
+    }
+
+    .lightbox-text {
+        max-width: none;
+        margin-top: 10px;
+    }
+}
+
 @keyframes glow {
     from {
         text-shadow: 0 0 5px #0f0, 0 0 10px #0f0, 0 0 20px #0f0;


### PR DESCRIPTION
## Summary
- ensure lightbox text sits below the image when a tablet is in portrait orientation

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687ca209c250832ca77504822cd435c8