### PR TITLE
Add dynamic hacker boot sequence

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,10 +11,7 @@
 </head>
 <body>
     <div id="boot-screen">
-        <div class="boot-container">
-            <div class="boot-line">YUEPLUSH CYBER BIOS v1.0</div>
-            <div class="boot-line boot-blink">INITIALIZING...</div>
-        </div>
+        <div class="boot-container"></div>
     </div>
     <div class="background-animation"></div>
     <canvas id="bubble-canvas"></canvas>

--- a/script.js
+++ b/script.js
@@ -311,8 +311,40 @@ function initBootScreen() {
     const boot = document.getElementById('boot-screen');
     if (!boot) return;
 
-    setTimeout(() => {
-        boot.classList.add('fade-out');
-        boot.addEventListener('animationend', () => boot.remove());
-    }, 2000);
+    const container = boot.querySelector('.boot-container');
+    const lines = [
+        'YUEPLUSH CYBER BIOS v1.0',
+        '<span class="boot-blink">INITIALIZING...</span>',
+        'Access from external network... <span class="boot-status">Approved</span>',
+        'System boot... <span class="boot-status">Initialize</span>',
+        'CPU... <span class="boot-status">OK</span>',
+        'GPU... <span class="boot-status">OK</span>',
+        'RAM... <span class="boot-status">OK</span>',
+        'Storage... <span class="boot-status">OK</span>',
+        'Security protocols... <span class="boot-status">Enabled</span>',
+        'Welcome, stranger, take easy for moment',
+        'Cybernetic link process v1.12 booted up, <span class="boot-status">Accepted</span>',
+        '<span class="boot-blink">Screen changes...3...2...1...</span>'
+    ];
+
+    let index = 0;
+    const delay = 700;
+
+    function addLine() {
+        if (index >= lines.length) {
+            setTimeout(() => {
+                boot.classList.add('fade-out');
+                boot.addEventListener('animationend', () => boot.remove());
+            }, 600);
+            return;
+        }
+        const div = document.createElement('div');
+        div.className = 'boot-line';
+        div.innerHTML = lines[index];
+        container.appendChild(div);
+        index++;
+        setTimeout(addLine, delay);
+    }
+
+    addLine();
 }

--- a/style.css
+++ b/style.css
@@ -40,12 +40,12 @@ body {
     animation: bootSlideIn 0.6s ease forwards;
 }
 
-.boot-line:nth-child(2) {
-    animation-delay: 0.4s;
-}
-
 .boot-blink {
     animation: bootSlideIn 0.6s ease forwards, blink 1s steps(1) infinite 1.4s;
+}
+
+.boot-status {
+    color: #0f0;
 }
 
 @keyframes bootSlideIn {


### PR DESCRIPTION
## Summary
- make boot screen container empty for JS lines
- remove nth-child delay rule and add `.boot-status` style
- show boot sequence lines dynamically in JS

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/yueplushart/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_687cac3d7558832c9b5cfa98ba5bff59