### PR TITLE
Add boot screen skip and tweak style

### DIFF
--- a/script.js
+++ b/script.js
@@ -329,13 +329,18 @@ function initBootScreen() {
 
     let index = 0;
     const delay = 700;
+    let timer;
+
+    function finishBoot() {
+        if (boot.classList.contains('fade-out')) return;
+        clearTimeout(timer);
+        boot.classList.add('fade-out');
+        boot.addEventListener('animationend', () => boot.remove());
+    }
 
     function addLine() {
         if (index >= lines.length) {
-            setTimeout(() => {
-                boot.classList.add('fade-out');
-                boot.addEventListener('animationend', () => boot.remove());
-            }, 600);
+            timer = setTimeout(finishBoot, 600);
             return;
         }
         const div = document.createElement('div');
@@ -343,8 +348,11 @@ function initBootScreen() {
         div.innerHTML = lines[index];
         container.appendChild(div);
         index++;
-        setTimeout(addLine, delay);
+        timer = setTimeout(addLine, delay);
     }
+
+    boot.addEventListener('click', finishBoot);
+    boot.addEventListener('touchstart', finishBoot);
 
     addLine();
 }

--- a/style.css
+++ b/style.css
@@ -17,8 +17,10 @@ body {
     height: 100%;
     background: radial-gradient(circle at center, #001 0%, #000 80%);
     display: flex;
-    justify-content: center;
-    align-items: center;
+    justify-content: flex-start;
+    align-items: flex-start;
+    padding: 40px;
+    box-sizing: border-box;
     z-index: 10000;
     overflow: hidden;
 }
@@ -28,14 +30,15 @@ body {
 }
 
 .boot-container {
-    text-align: center;
+    text-align: left;
 }
 
 .boot-line {
     font-family: 'Share Tech Mono', monospace;
     color: #0f0;
     font-size: 1.6em;
-    text-shadow: 0 0 5px #0f0, 0 0 15px #0f0;
+    letter-spacing: 0.05em;
+    text-shadow: 0 0 8px #0f0, 0 0 18px #0f0, 0 0 30px #0ff;
     opacity: 0;
     animation: bootSlideIn 0.6s ease forwards;
 }


### PR DESCRIPTION
## Summary
- style boot screen to show text in the upper left with a stronger glow
- allow skipping the boot sequence by click/tap

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687cadd84028832ca46f205407ea35bd