### PR TITLE
Fix hero header line break

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
     <canvas id="bubble-canvas"></canvas>
 
     <section id="hero">
-        <h1>YuePlush – <strong>100% Hand-Drawn</strong><br class="mobile-break">Seasoned Artist with 30+ Years of Experience</h1>
+        <h1>YuePlush – <strong>100% Hand-Drawn</strong><br>Seasoned Artist with 30+ Years of Experience</h1>
         <p class="hero-subtitle">Creative and Theory, YOU can do this!</p>
     </section>
 

--- a/style.css
+++ b/style.css
@@ -316,16 +316,6 @@ main {
     font-size: 1em;
 }
 
-.mobile-break {
-    display: none;
-}
-
-@media (max-width: 600px) {
-    .mobile-break {
-        display: inline;
-    }
-}
-
 .content-section {
     padding: 80px 20px;
     margin: 0 auto;


### PR DESCRIPTION
## Summary
- show hero header text on two lines for all screen sizes
- remove obsolete CSS for mobile-only line break

## Testing
- `grep -n "Hand-Drawn" -n index.html`


------
https://chatgpt.com/codex/tasks/task_e_687cbca0a63c832cae76df3829c071d8