### PR TITLE
Implement fade transitions for boot skip

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
     <div class="background-animation"></div>
     <canvas id="bubble-canvas"></canvas>
 
-    <section id="hero">
+    <section id="hero" class="hidden">
         <h1>YuePlush – <strong>100% Hand-Drawn</strong><br>Seasoned Artist with 30+ Years of Experience</h1>
         <p class="hero-subtitle">Creative and Theory, YOU can do this!</p>
     </section>

--- a/script.js
+++ b/script.js
@@ -11,14 +11,14 @@ function initNavigation() {
     const heroSection = document.getElementById('hero');
     const menuToggle = document.querySelector('.menu-toggle');
     const nav = document.querySelector('header nav');
-    let activeSection = heroSection;
+    let activeSection = null;
 
     // Hide all content sections initially
     document.querySelectorAll('.content-section.hidden').forEach(sec => {
         sec.style.display = 'none';
     });
 
-    heroSection.classList.add('visible');
+    heroSection.classList.add('hidden');
 
     function fadeOut(element) {
         return new Promise(resolve => {
@@ -58,6 +58,12 @@ function initNavigation() {
     }
 
     heroSection.addEventListener('click', () => showSection(null));
+
+    document.addEventListener('bootFinished', () => {
+        fadeIn(heroSection).then(() => {
+            activeSection = heroSection;
+        });
+    });
 
     const menu = nav.querySelector('ul');
 
@@ -347,6 +353,7 @@ function initBootScreen() {
         if (boot.classList.contains('fade-out')) return;
         clearTimeout(timer);
         boot.classList.add('fade-out');
+        document.dispatchEvent(new Event('bootFinished'));
         if (crt) {
             crt.classList.add('fade-out');
             crt.addEventListener('animationend', () => crt.remove());


### PR DESCRIPTION
## Summary
- hide the hero section initially
- show the hero section after boot via custom `bootFinished` event
- dispatch `bootFinished` when the boot screen fades out

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687cd613da10832c89e9536c27199902