### PR TITLE
Adjust hero overlay to cover full screen

### DIFF
--- a/style.css
+++ b/style.css
@@ -309,19 +309,20 @@ main {
 
 #hero {
     position: fixed;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
+    top: 0;
+    left: 0;
     width: 100%;
+    height: 100vh;
     padding: 0 20px;
     box-sizing: border-box;
     display: flex;
     flex-direction: column;
+    justify-content: center;
     align-items: center;
     text-align: center;
-    background-color: rgba(0, 0, 0, 0.7); /* ヒーローセクションの背景色を調整 */
+    background-color: rgba(0, 0, 0, 0.9); /* 画面全体を覆う黒背景 */
     color: #fff;
-    z-index: 99; /* ヘッダーの下、コンテンツの上に配置 */
+    z-index: 101; /* ヘッダーより前面に配置 */
     transition: opacity 0.5s ease-in-out;
 }
 


### PR DESCRIPTION
## Summary
- make the hero section cover the entire viewport and sit above the header
- keep click-to-fade hero interaction

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687ce0c80148832ca384842fcd6d3faf