### PR TITLE
Add scanline overlay under content

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@
     <div id="crt-overlay"></div>
     <div class="background-animation"></div>
     <canvas id="bubble-canvas"></canvas>
+    <div id="scanline-overlay"></div>
 
     <section id="hero" class="hidden">
         <div class="hero-text">

--- a/style.css
+++ b/style.css
@@ -68,6 +68,23 @@ body {
     animation: crtFade 0.5s ease forwards;
 }
 
+#scanline-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    z-index: 0;
+    background: repeating-linear-gradient(0deg,
+        rgba(0,0,0,0.3) 0px,
+        rgba(0,0,0,0.3) 2px,
+        transparent 2px,
+        transparent 4px);
+    mix-blend-mode: multiply;
+    opacity: 0.5;
+}
+
 @keyframes crtFlicker {
     0%, 100% { opacity: 0.25; }
     50% { opacity: 0.3; }


### PR DESCRIPTION
## Summary
- add a scanline overlay layer below the main menu and content
- style the overlay with 50% opacity and multiply blend

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687ce7822cf0832c941290dd5f62d246