### PR TITLE
Adjust hero overlay transparency

### DIFF
--- a/style.css
+++ b/style.css
@@ -337,7 +337,7 @@ main {
     justify-content: center;
     align-items: center;
     text-align: left;
-    background-color: rgba(0, 0, 0, 0.9); /* 画面全体を覆う黒背景 */
+    background-color: rgba(0, 0, 0, 0.6); /* 画面全体を覆う黒背景を少し透過 */
     color: #fff;
     z-index: 101; /* ヘッダーより前面に配置 */
     transition: opacity 0.5s ease-in-out;


### PR DESCRIPTION
## Summary
- tweak `#hero` overlay to partially show menu items behind it

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687cf39ccc50832cb606da668989f76d