### PR TITLE
Fix Discord link text

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,7 +75,7 @@
                 <p class="contact-heading">Contact info:</p>
                 <div class="contact-links">
                     <p class="email"><a href="mailto:yueplushart[at]tutamail.com">📧</a></p>
-                    <p><a href="https://discord.gg/E2JVeWVHds" target="_blank" rel="noopener noreferrer">Cradle of the Moon - YuePlush's Private Discord Server</a></p>
+                    <p><a class="profile-link-btn" href="https://discord.gg/E2JVeWVHds" target="_blank" rel="noopener noreferrer">YuePlush's Private Discord Server</a></p>
                 </div>
             </div>
         </section>


### PR DESCRIPTION
## Summary
- shorten the Discord link text
- style the Discord link like other buttons

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d05192c4c832c8a205def839bec1d