### PR TITLE
Add avatar image to about section

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,6 +43,7 @@
 
         <section id="about" class="content-section hidden">
             <h2>About Me</h2>
+            <img src="https://yueplush-artwork.netlify.app/avatar.webp" alt="YuePlush avatar" class="about-avatar">
             <div class="about-content">
                 <p>
                     YuePlush<br>

--- a/style.css
+++ b/style.css
@@ -658,6 +658,15 @@ main {
     text-align: center;
 }
 
+#about .about-avatar {
+    display: block;
+    margin: 0 auto 20px;
+    max-width: 200px;
+    width: 50%;
+    height: auto;
+    border-radius: 50%;
+}
+
 #about .about-content {
     margin-left: auto;
     margin-right: auto;


### PR DESCRIPTION
## Summary
- insert avatar image between About Me heading and description
- style avatar with a maximum width and center alignment

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d23eee5f4832caa9511ed644bfafa