### PR TITLE
Add moneybag emoji before PayPal notice

### DIFF
--- a/index.html
+++ b/index.html
@@ -154,7 +154,7 @@
             <p>▶ +$10 – Suggestive themes (fetish only)</p>
             <p>▼Up to 2 minor revisions after sketch approval</p>
             <p>▼Turnaround: ~1–3 weeks (or up to 1–3 months if busy)</p>
-            <p>️Payment: PayPal only – No invoice, No refunds</p>
+            <p>💰️️Payment: PayPal only – No invoice, No refunds</p>
             <p>❌ Commercial use not allowed (ask for licensing)</p>
             <p>⭕ All characters I draw are fictional and over 21 years old</p>
             <p>Email me or message me on Discord, I’ll PM you.<br>Please include:<br>• Character reference images<br>• Pose idea or description<br>• Mood or theme (optional)</p>


### PR DESCRIPTION
## Summary
- highlight the PayPal payment notice with a moneybag emoji

## Testing
- `grep -n "PayPal" -n index.html`

------
https://chatgpt.com/codex/tasks/task_e_687d258f3c8c832c8074ca52818cbc98