### PR TITLE
Add overlay avatar on about page

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,8 @@
     <canvas id="bubble-canvas"></canvas>
     <div id="scanline-overlay"></div>
 
+    <img id="about-decor" class="hidden" src="https://yueplush-artwork.netlify.app/avatar_full.webp" alt="Decorative avatar">
+
     <section id="hero" class="hidden">
         <div class="hero-text">
         <h1>YuePlush – <strong>100% Hand-Drawn</strong><br>Seasoned Artist with 30+ Years of Experience</h1>

--- a/script.js
+++ b/script.js
@@ -13,6 +13,8 @@
     const initNavigation = () => {
         const navLinks = document.querySelectorAll('nav a[data-section]');
         const heroSection = document.getElementById('hero');
+        const aboutSection = document.getElementById('about');
+        const aboutDecor = document.getElementById('about-decor');
         const menuToggle = document.querySelector('.menu-toggle');
         const nav = document.querySelector('header nav');
         let activeSection = null;
@@ -59,6 +61,16 @@
         if (activeSection) await fadeOut(activeSection);
         activeSection = section;
         if (section) await fadeIn(section);
+
+        if (aboutDecor && window.matchMedia('(min-width: 601px)').matches) {
+            if (section === aboutSection) {
+                fadeIn(aboutDecor);
+            } else {
+                fadeOut(aboutDecor);
+            }
+        } else if (aboutDecor) {
+            fadeOut(aboutDecor);
+        }
     }
 
     heroSection.addEventListener('click', () => showSection(null));

--- a/style.css
+++ b/style.css
@@ -654,6 +654,35 @@ main {
     text-align: left;
 }
 
+#about-decor {
+    position: fixed;
+    bottom: 0;
+    right: 0;
+    width: 30%;
+    max-width: 450px;
+    height: auto;
+    pointer-events: none;
+    z-index: 102;
+    opacity: 0;
+    display: none;
+    transition: opacity 0.5s ease;
+}
+
+#about-decor.visible {
+    display: block;
+    opacity: 1;
+}
+
+#about-decor.hidden {
+    opacity: 0;
+}
+
+@media (max-width: 600px) {
+    #about-decor {
+        display: none !important;
+    }
+}
+
 #about h2 {
     text-align: center;
 }


### PR DESCRIPTION
## Summary
- overlay avatar on About section for PC/tablet
- fade in/out the overlay when navigating

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_687d266c089c832cb27708275e6ad052