### PR TITLE
Fix alignment for Commission section header

### DIFF
--- a/style.css
+++ b/style.css
@@ -653,6 +653,11 @@ main {
 
 #commission h2 {
     text-align: left;
+    margin-left: auto;
+    margin-right: auto;
+    padding-left: 1.5rem;
+    padding-right: 1.5rem;
+    max-width: 760px;
 }
 
 #commission .commission-content {
@@ -664,7 +669,8 @@ main {
 }
 
 @media (min-width: 768px) {
-    #commission .commission-content {
+    #commission .commission-content,
+    #commission h2 {
         padding-left: 3rem;
         padding-right: 3rem;
     }


### PR DESCRIPTION
## Summary
- align the `Commission` heading with its content
- apply responsive padding for consistency

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d38a9ef34832ca0a832a4b71caa6c