### PR TITLE
Stack about section content vertically

### DIFF
--- a/style.css
+++ b/style.css
@@ -731,7 +731,7 @@ main {
 
 #about .about-avatar {
     display: block;
-    margin: 0 20px 20px 0;
+    margin: 0 auto 20px;
     width: 150px;
     max-width: 200px;
     height: auto;
@@ -746,8 +746,8 @@ main {
     padding-right: 1.5rem;
     max-width: 760px;
     display: flex;
-    flex-wrap: wrap;
-    align-items: flex-start;
+    flex-direction: column;
+    align-items: center;
     gap: 20px;
 }
 
@@ -763,13 +763,8 @@ main {
 }
 
 @media (max-width: 600px) {
-    #about .about-content {
-        flex-direction: column;
-        align-items: flex-start;
-    }
     #about .about-avatar {
         width: 50%;
-        margin-right: 0;
     }
 }
 


### PR DESCRIPTION
## Summary
- tweak CSS to always stack the avatar and profile text vertically
- center avatar and align the layout

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d3ca7a104832cb4d724496397b229