### PR TITLE
Fix hero tagline layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -367,6 +367,7 @@ main {
     font-size: 3em;
     margin-bottom: 10px;
     text-align: center;
+    white-space: nowrap;
 }
 
 #hero p {
@@ -382,7 +383,7 @@ main {
     display: inline-block;
     text-align: center;
     width: auto;
-    max-width: 800px;
+    max-width: none;
 }
 
 .hero-subtitle {
@@ -570,6 +571,7 @@ main {
     #hero h1 {
         font-size: 1.6em;
         line-height: 1.3;
+        white-space: nowrap;
     }
 
     #hero p {
@@ -597,6 +599,7 @@ main {
 
     #hero h1 {
         font-size: 2.5em;
+        white-space: nowrap;
     }
 
     #hero p {
@@ -997,6 +1000,7 @@ main {
 
     #hero h1 {
         font-size: 2.8em;
+        white-space: nowrap;
     }
 
     #hero p {


### PR DESCRIPTION
## Summary
- ensure hero tagline shows on exactly two lines
- allow hero text to expand without wrapping

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d3de61e30832ca9d66f8361f49a0d