### PR TITLE
Add circular avatar to About section

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,6 +46,7 @@
         <section id="about" class="content-section hidden">
             <h2>About Me</h2>
             <div class="about-content">
+                <img src="https://yueplush-artwork.netlify.app/avatar.webp" alt="Avatar" class="about-avatar">
                 <div class="about-text">
                     <p>
                         YuePlush<br>


### PR DESCRIPTION
## Summary
- show a new avatar between **About Me** and profile text
- use existing `.about-avatar` style to keep it round and responsive

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d452a4060832cb75df72c99766a5d