### PR TITLE
Fix about section layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -771,19 +771,12 @@ main {
 
 @media (min-width: 768px) {
     #about .about-content {
-        flex-direction: row;
-        align-items: center;
         padding-left: 3rem;
         padding-right: 3rem;
     }
 
     #about .about-avatar {
-        margin: 0 20px 0 0;
         width: 200px;
-    }
-
-    #about .about-text {
-        margin-left: 0;
     }
 }
 


### PR DESCRIPTION
## Summary
- ensure the avatar image remains above the about section text on all viewports

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687da75c6b60832cad2cf2ad69f804ee