### PR TITLE
Align About section text

### DIFF
--- a/style.css
+++ b/style.css
@@ -761,12 +761,13 @@ main {
     max-width: 760px;
     display: flex;
     flex-direction: column;
-    align-items: center;
+    align-items: flex-start; /* align content with left line */
     gap: 20px;
 }
 
 #about .about-text {
     flex: 1;
+    width: 100%; /* ensure text lines align */
 }
 
 @media (min-width: 768px) {


### PR DESCRIPTION
## Summary
- ensure the about section uses left alignment so that its content lines up with the rest of the page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687dadabaaec832ca81ae98780a44e4b