### PR TITLE
Improve hero text layout for mobile portrait

### DIFF
--- a/style.css
+++ b/style.css
@@ -993,9 +993,15 @@ main {
         text-align: center;
     }
 
-    .lightbox-text {
-        max-width: none;
-        margin-top: 10px;
+.lightbox-text {
+    max-width: none;
+    margin-top: 10px;
+}
+}
+
+@media (max-width: 600px) and (orientation: portrait) {
+    .hero-text {
+        max-width: 90%;
     }
 }
 


### PR DESCRIPTION
## Summary
- add CSS rule for portrait mobile devices so hero text uses 90% of the screen width

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_687daf6354c4832c80f935cc2e25171a