### PR TITLE
Fix avatar alignment

### DIFF
--- a/style.css
+++ b/style.css
@@ -745,7 +745,7 @@ main {
 
 #about .about-avatar {
     display: block;
-    margin: 0 auto 20px;
+    margin: 0 0 20px; /* align avatar with left text */
     width: 150px;
     max-width: 200px;
     height: auto;


### PR DESCRIPTION
## Summary
- left-align the avatar image in the About section by adjusting CSS

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_687db078fe20832cabfec641b9ae6136