### PR TITLE
Fix hero text layout on small screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
 
     <section id="hero" class="hidden">
         <div class="hero-text">
-        <h1>YuePlush – <strong>100% Hand-Drawn</strong><wbr> Seasoned Artist<br><span class="years-exp">with 30+ Years of Experience</span></h1>
+        <h1>YuePlush – <strong>100% Hand-Drawn</strong> Seasoned Artist<br><span class="years-exp">with 30+ Years of Experience</span></h1>
         <p class="hero-subtitle" style="text-align: right;">Creative and Theory, YOU can do this!</p>
         </div>
     </section>

--- a/style.css
+++ b/style.css
@@ -1001,7 +1001,7 @@ main {
 
 @media (max-width: 600px) and (orientation: portrait) {
     .hero-text {
-        max-width: 90%;
+        max-width: 96%;
     }
 }
 


### PR DESCRIPTION
## Summary
- remove forced `<wbr>` break from hero title
- allow a little wider hero text on phones

## Testing
- `grep -n "Hand-Drawn" -n index.html`


------
https://chatgpt.com/codex/tasks/task_e_687db1716d2c832c83fc6395fe95ae9b