### PR TITLE
Fix hero subtitle alignment for mobile and tablet

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
     <section id="hero" class="hidden">
         <div class="hero-text">
         <h1>YuePlush – <strong>100% Hand-Drawn</strong> Seasoned Artist<br><span class="years-exp">with 30+ Years of Experience</span></h1>
-        <p class="hero-subtitle" style="text-align: right;">Creative and Theory, YOU can do this!</p>
+        <p class="hero-subtitle">Creative and Theory, YOU can do this!</p>
         </div>
     </section>
 

--- a/style.css
+++ b/style.css
@@ -584,6 +584,10 @@ main {
         font-size: 0.9em;
     }
 
+    .hero-subtitle {
+        text-align: center;
+    }
+
     .content-section {
         padding: 60px 15px;
     }
@@ -610,6 +614,10 @@ main {
 
     #hero p {
         font-size: 1.1em;
+    }
+
+    .hero-subtitle {
+        text-align: center;
     }
 
     .content-section {


### PR DESCRIPTION
## Summary
- remove inline style from hero subtitle
- center hero subtitle on smartphones and tablets

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687db548214c832c8756d637fa9deaaf