### PR TITLE
Adjust hero text layout on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
 
     <section id="hero" class="hidden">
         <div class="hero-text">
-        <h1>YuePlush – <strong>100% Hand-Drawn</strong> Seasoned Artist<br><span class="years-exp">with 30+ Years of Experience</span></h1>
+        <h1>YuePlush – <strong>100% Hand-Drawn</strong> Seasoned Artist<br class="hero-break"><span class="years-exp">with 30+ Years of Experience</span></h1>
         <p class="hero-subtitle">Creative and Theory, YOU can do this!</p>
         </div>
     </section>

--- a/style.css
+++ b/style.css
@@ -599,6 +599,15 @@ main {
     .artwork-item {
         width: 100%;
     }
+
+    br.hero-break {
+        display: none;
+    }
+
+    .years-exp {
+        display: inline;
+        text-align: center;
+    }
 }
 
 @media (min-width: 601px) and (max-width: 1024px) {


### PR DESCRIPTION
## Summary
- allow removing hero tagline break on mobile
- keep tagline inline and centered for small screens

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687dbc0ec52c832ca6118a2d43f8316b