### PR TITLE
Improve mobile hero text layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -575,13 +575,13 @@ main {
     }
 
     #hero h1 {
-        font-size: 1.6em;
-        line-height: 1.3;
+        font-size: 1.2em;
+        line-height: 1.2;
         white-space: normal;
     }
 
     #hero p {
-        font-size: 0.9em;
+        font-size: 0.8em;
     }
 
     .hero-subtitle {
@@ -1018,7 +1018,7 @@ main {
 
 @media (max-width: 600px) and (orientation: portrait) {
     .hero-text {
-        max-width: 96%;
+        max-width: 100%;
     }
 }
 


### PR DESCRIPTION
## Summary
- tweak hero section font sizes for small screens
- allow hero text container to use full width in portrait mode

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687dbe61b9cc832ca62ababe28c61731