### PR TITLE
Center About Me on mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -809,6 +809,15 @@ main {
         display: block;
     }
 
+    #about,
+    #about h2 {
+        text-align: center;
+    }
+
+    #about .about-content {
+        align-items: center;
+    }
+
     #about .about-text p:first-child {
         margin-top: 0;
     }


### PR DESCRIPTION
## Summary
- center the About Me section for small screens

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687dce3aaffc832cae82896c2618fcbe