### PR TITLE
Fix hero layout on tablets

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
 
     <section id="hero" class="hidden">
         <div class="hero-text">
-        <h1>YuePlush – <strong>100% Hand-Drawn</strong> Seasoned Artist<br class="hero-break"><span class="years-exp">with 30+ Years of Experience</span></h1>
+        <h1>YuePlush – <strong>100% Hand-Drawn</strong><br class="tablet-break"> Seasoned Artist<br class="hero-break"><span class="years-exp">with 30+ Years of Experience</span></h1>
         <p class="hero-subtitle">Creative and Theory, YOU can do this!</p>
         </div>
     </section>

--- a/style.css
+++ b/style.css
@@ -399,6 +399,10 @@ main {
     white-space: nowrap;
 }
 
+br.tablet-break {
+    display: none;
+}
+
 .content-section {
     padding: 80px 20px;
     margin: 0 auto;
@@ -1092,11 +1096,19 @@ main {
     }
 }
 
-/* Keep PC-style headline wrapping on tablets */
+/* Tablet portrait adjustments */
 @media (min-width: 601px) and (max-width: 1024px) and (orientation: portrait) {
-    #hero h1,
+    #hero h1 {
+        font-size: 2.4em;
+        white-space: normal;
+    }
+
     .years-exp {
-        white-space: nowrap;
+        white-space: normal;
+    }
+
+    br.tablet-break {
+        display: inline;
     }
 }
 


### PR DESCRIPTION
## Summary
- adjust hero headline in `index.html` with a tablet-only break
- hide the new break by default and show it on tablet portrait
- allow wrapping and shrink font size for tablet portrait screens

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687dd7918f20832ca8c9ce3f20a0cf54