### PR TITLE
Fix hero subtitle alignment

### DIFF
--- a/style.css
+++ b/style.css
@@ -384,8 +384,8 @@ main {
     transform: translate(-50%, -50%);
     display: inline-block;
     text-align: center;
-    width: auto;
-    max-width: none;
+    width: 100%;
+    max-width: 960px;
 }
 
 .hero-subtitle {


### PR DESCRIPTION
## Summary
- ensure hero text area spans entire hero width
- this allows `.hero-subtitle` to align right properly

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_687ef2ff2f68832cb0573eacbbe7e472