### PR TITLE
Add Commission Art filter option

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ they are adults. After confirming, subcategories such as Bubbles, Balloons,
 Pooltoy and Other become available. No suggestive artwork is shown until one of
 these subcategories is chosen.
 
+The gallery includes filter buttons for **ALL**, **SFW Art**, **Suggestive Art**,
+**Commission Art**, **3D Model** and **OCs**. Items tagged as both
+Commission and Suggestive stay hidden in the Commission and ALL views until the
+adult confirmation checkbox has been enabled.
+
 Tapping an artwork opens it in a full screen view. Clicking or tapping the
 full image again fades it out and closes the lightbox on desktop, tablets and
 smartphones alike for consistent navigation across devices. The layout also

--- a/index.html
+++ b/index.html
@@ -95,6 +95,7 @@
                 <button class="filter-btn active" data-filter="all">ALL</button>
                 <button class="filter-btn" data-filter="sfw">SFW Art</button>
                 <button class="filter-btn" data-filter="suggestive">Suggestive Art</button>
+                <button class="filter-btn" data-filter="commission">Commission Art</button>
                 <button class="filter-btn" data-filter="3d">3D Model</button>
                 <button class="filter-btn" data-filter="ocs">OCs</button>
             </div>
@@ -131,6 +132,20 @@
                     <div class="art-info">
                         <h3>Book of Bubbles</h3>
                         <p>I'm flying at the night!</p>
+                    </div>
+                </div>
+                <div class="artwork-item square" data-tags="commission sfw" data-title="Commission SFW" data-desc="Sample SFW commission piece">
+                    <img src="https://yueplush-artwork.netlify.app/devil_optimized.webp" alt="Commission SFW">
+                    <div class="art-info">
+                        <h3>Commission - SFW</h3>
+                        <p>Sample SFW commission piece</p>
+                    </div>
+                </div>
+                <div class="artwork-item square" data-tags="commission suggestive balloons" data-title="Commission Balloons" data-desc="Suggestive commission with balloons">
+                    <img src="https://yueplush-artwork.netlify.app/bubble1_optimized.webp" alt="Commission Balloons">
+                    <div class="art-info">
+                        <h3>Commission - Balloons</h3>
+                        <p>Suggestive commission with balloons</p>
                     </div>
                 </div>
                 <!-- 必要に応じてさらに作品を追加 -->

--- a/script.js
+++ b/script.js
@@ -219,7 +219,7 @@
                     if (currentFilter === 'suggestive' && !currentSub) {
                         visible = false;
                     }
-                    if (currentFilter === 'all' && !adultOk && isSuggestive) {
+                    if ((currentFilter === 'all' || currentFilter === 'commission') && !adultOk && isSuggestive) {
                         visible = false;
                     }
 


### PR DESCRIPTION
## Summary
- add new button for `Commission Art` in the gallery filter
- hide suggestive commission art until adult check is confirmed
- document the new filter in README
- include a couple of sample commission items

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_687f1c85eaf0832cb33852b84d588f02