### PR TITLE
Add CRT distortion during boot screen

### DIFF
--- a/boot-config.json
+++ b/boot-config.json
@@ -1,0 +1,7 @@
+{
+    "crt": {
+        "baseFrequencyX": 0.003,
+        "baseFrequencyY": 0.006,
+        "scale": 20
+    }
+}

--- a/index.html
+++ b/index.html
@@ -19,6 +19,12 @@
     <div class="background-animation"></div>
     <canvas id="bubble-canvas"></canvas>
     <div id="scanline-overlay"></div>
+    <svg id="crt-filters" xmlns="http://www.w3.org/2000/svg" style="position:absolute;width:0;height:0;overflow:hidden;">
+        <filter id="crt-distortion">
+            <feTurbulence type="fractalNoise" baseFrequency="0.003 0.006" numOctaves="2" result="turb" />
+            <feDisplacementMap in="SourceGraphic" in2="turb" scale="20" xChannelSelector="R" yChannelSelector="G" />
+        </filter>
+    </svg>
 
     <img id="about-decor" class="hidden" src="https://yueplush-artwork.netlify.app/avatar_full.webp" alt="Decorative avatar">
 

--- a/script.js
+++ b/script.js
@@ -410,7 +410,25 @@
         init() {
             const boot = document.getElementById('boot-screen');
             const crt = document.getElementById('crt-overlay');
+            const filter = document.getElementById('crt-distortion');
             if (!boot) return;
+
+            if (filter) {
+                fetch('boot-config.json')
+                    .then(r => r.ok ? r.json() : null)
+                    .then(cfg => {
+                        if (!cfg || !cfg.crt) return;
+                        const turb = filter.querySelector('feTurbulence');
+                        const disp = filter.querySelector('feDisplacementMap');
+                        if (turb && cfg.crt.baseFrequencyX && cfg.crt.baseFrequencyY) {
+                            turb.setAttribute('baseFrequency', `${cfg.crt.baseFrequencyX} ${cfg.crt.baseFrequencyY}`);
+                        }
+                        if (disp && cfg.crt.scale) {
+                            disp.setAttribute('scale', cfg.crt.scale);
+                        }
+                    })
+                    .catch(() => {});
+            }
 
             const container = boot.querySelector('.boot-container');
             let index = 0;

--- a/style.css
+++ b/style.css
@@ -18,6 +18,8 @@ body {
     width: 100%;
     height: 100%;
     background: radial-gradient(circle at center, #001 0%, #000 80%);
+    filter: url(#crt-distortion);
+    transform: scale(1.01);
     display: flex;
     justify-content: flex-start;
     align-items: flex-start;


### PR DESCRIPTION
## Summary
- add SVG filter for CRT style distortion
- apply distortion to boot splash
- load parameters from `boot-config.json`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687f4b2bb42c832c8993596b2c435908