### PR TITLE
Lazy load images on artwork section

### DIFF
--- a/index.html
+++ b/index.html
@@ -107,28 +107,28 @@
             </div>
             <div class="artwork-gallery">
                 <div class="artwork-item square" data-tags="sfw" data-title="devil" data-desc="or cosplay something">
-                    <img src="https://yueplush-artwork.netlify.app/devil_optimized.webp" alt="devil">
+                    <img data-src="https://yueplush-artwork.netlify.app/devil_optimized.webp" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==" loading="lazy" class="lazy" alt="devil">
                     <div class="art-info">
                         <h3>devil</h3>
                         <p>or cosplay something</p>
                     </div>
                 </div>
                 <div class="artwork-item square" data-tags="sfw" data-title="Mt.Fuji scenery" data-desc="This was exhibited at an exhibition in Kumamoto, Japan.">
-                    <img src="https://yueplush-artwork.netlify.app/mt-fuji_optimized.webp" alt="Mt.Fuji scenery">
+                    <img data-src="https://yueplush-artwork.netlify.app/mt-fuji_optimized.webp" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==" loading="lazy" class="lazy" alt="Mt.Fuji scenery">
                     <div class="art-info">
                         <h3>Mt.Fuji scenery</h3>
                         <p>This was exhibited at an exhibition in Kumamoto, Japan.</p>
                     </div>
                 </div>
                 <div class="artwork-item square" data-tags="sfw" data-title="Militia" data-desc="we need some backup for the this place">
-                    <img src="https://yueplush-artwork.netlify.app/militia_optimized.webp" alt="Militia">
+                    <img data-src="https://yueplush-artwork.netlify.app/militia_optimized.webp" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==" loading="lazy" class="lazy" alt="Militia">
                     <div class="art-info">
                         <h3>Militia</h3>
                         <p>we need some backup for the this place</p>
                     </div>
                 </div>
                 <div class="artwork-item square" data-tags="suggestive bubbles" data-title="Book of Bubbles" data-desc="I'm flying at the night!">
-                    <img src="https://yueplush-artwork.netlify.app/bubble1_optimized.webp" alt="Book of Bubbles">
+                    <img data-src="https://yueplush-artwork.netlify.app/bubble1_optimized.webp" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==" loading="lazy" class="lazy" alt="Book of Bubbles">
                     <div class="art-info">
                         <h3>Book of Bubbles</h3>
                         <p>I'm flying at the night!</p>


### PR DESCRIPTION
## Summary
- add data-src placeholders for artwork images
- initialize lazy loading only when the `My Artwork` section is opened
- simplify app init without eager image loading

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687f519facfc832c8cd4f520f29a7f00