### PR TITLE
Improve artwork loading

### DIFF
--- a/index.html
+++ b/index.html
@@ -107,28 +107,28 @@
             </div>
             <div class="artwork-gallery">
                 <div class="artwork-item square" data-tags="sfw" data-title="devil" data-desc="or cosplay something">
-                    <img data-src="https://yueplush-artwork.netlify.app/devil_optimized.webp" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==" loading="lazy" class="lazy" alt="devil">
+                    <img data-src="https://yueplush-artwork.netlify.app/devil_optimized.webp" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==" class="lazy" alt="devil">
                     <div class="art-info">
                         <h3>devil</h3>
                         <p>or cosplay something</p>
                     </div>
                 </div>
                 <div class="artwork-item square" data-tags="sfw" data-title="Mt.Fuji scenery" data-desc="This was exhibited at an exhibition in Kumamoto, Japan.">
-                    <img data-src="https://yueplush-artwork.netlify.app/mt-fuji_optimized.webp" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==" loading="lazy" class="lazy" alt="Mt.Fuji scenery">
+                    <img data-src="https://yueplush-artwork.netlify.app/mt-fuji_optimized.webp" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==" class="lazy" alt="Mt.Fuji scenery">
                     <div class="art-info">
                         <h3>Mt.Fuji scenery</h3>
                         <p>This was exhibited at an exhibition in Kumamoto, Japan.</p>
                     </div>
                 </div>
                 <div class="artwork-item square" data-tags="sfw" data-title="Militia" data-desc="we need some backup for the this place">
-                    <img data-src="https://yueplush-artwork.netlify.app/militia_optimized.webp" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==" loading="lazy" class="lazy" alt="Militia">
+                    <img data-src="https://yueplush-artwork.netlify.app/militia_optimized.webp" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==" class="lazy" alt="Militia">
                     <div class="art-info">
                         <h3>Militia</h3>
                         <p>we need some backup for the this place</p>
                     </div>
                 </div>
                 <div class="artwork-item square" data-tags="suggestive bubbles" data-title="Book of Bubbles" data-desc="I'm flying at the night!">
-                    <img data-src="https://yueplush-artwork.netlify.app/bubble1_optimized.webp" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==" loading="lazy" class="lazy" alt="Book of Bubbles">
+                    <img data-src="https://yueplush-artwork.netlify.app/bubble1_optimized.webp" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==" class="lazy" alt="Book of Bubbles">
                     <div class="art-info">
                         <h3>Book of Bubbles</h3>
                         <p>I'm flying at the night!</p>

--- a/script.js
+++ b/script.js
@@ -353,6 +353,8 @@
                 img.classList.remove('lazy');
             };
 
+            const preloadCount = 6;
+
             if (!('IntersectionObserver' in window)) {
                 images.forEach(loadImg);
                 return;
@@ -367,7 +369,13 @@
                 });
             }, { rootMargin: '100px 0px' });
 
-            images.forEach(img => observer.observe(img));
+            images.forEach((img, idx) => {
+                if (idx < preloadCount) {
+                    loadImg(img);
+                } else {
+                    observer.observe(img);
+                }
+            });
         }
     };
 


### PR DESCRIPTION
## Summary
- remove `loading="lazy"` from gallery images
- preload six artworks when opening My Artwork
- lazily load the rest via IntersectionObserver

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687f5362c9e0832c95f1e27a359ca93e