### PR TITLE
Improve artwork image loading

### DIFF
--- a/script.js
+++ b/script.js
@@ -339,7 +339,7 @@
 
     const LazyLoadArtwork = {
         initialized: false,
-        init() {
+        init(immediate = false) {
             if (this.initialized) return;
             const images = document.querySelectorAll('#my-artwork .artwork-gallery img[data-src]');
             if (!images.length) return;
@@ -355,7 +355,7 @@
 
             const preloadCount = 6;
 
-            if (!('IntersectionObserver' in window)) {
+            if (immediate || !('IntersectionObserver' in window)) {
                 images.forEach(loadImg);
                 return;
             }
@@ -459,6 +459,7 @@
             Lightbox.init();
             BubbleAnimation.init();
             ProfileToggle.init();
+            LazyLoadArtwork.init(true);
         }
     };
 


### PR DESCRIPTION
## Summary
- tweak lazy loader to optionally load all images immediately
- initialize My Artwork preload when page boots

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687f54df15c4832c8f92728152468102