### PR TITLE
Remove CRT filter from boot screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,12 +19,6 @@
     <div class="background-animation"></div>
     <canvas id="bubble-canvas"></canvas>
     <div id="scanline-overlay"></div>
-    <svg id="crt-filters" xmlns="http://www.w3.org/2000/svg" style="position:absolute;width:0;height:0;overflow:hidden;">
-        <filter id="crt-distortion">
-            <feImage xlink:href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3CradialGradient id='g' cx='50%25' cy='50%25' r='70%25'%3E%3Cstop offset='0%25' stop-color='white'/%3E%3Cstop offset='100%25' stop-color='black'/%3E%3C/radialGradient%3E%3Crect width='100%25' height='100%25' fill='url(%23g)'/%3E%3C/svg%3E" result="map" preserveAspectRatio="none" />
-            <feDisplacementMap in="SourceGraphic" in2="map" scale="40" xChannelSelector="R" yChannelSelector="G" />
-        </filter>
-    </svg>
 
     <img id="about-decor" class="hidden" src="https://yueplush-artwork.netlify.app/avatar_full.webp" alt="Decorative avatar">
 

--- a/style.css
+++ b/style.css
@@ -18,9 +18,7 @@ body {
     left: 0;
     width: 100vw;
     height: 100vh;
-    background: radial-gradient(circle at center, #001 0%, #000 80%);
-    background-color: #000;
-    filter: url(#crt-distortion);
+    background: #000;
     transform: scale(1.01);
     display: flex;
     justify-content: flex-start;


### PR DESCRIPTION
## Summary
- clean up boot screen filters
- use a solid black background for the boot screen

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687f5c43aa54832cbfa16d15bd42769d