### PR TITLE
Adjust scanline overlay intensity

### DIFF
--- a/style.css
+++ b/style.css
@@ -81,12 +81,12 @@ body {
     pointer-events: none;
     z-index: 0;
     background: repeating-linear-gradient(0deg,
-        rgba(0,0,0,0.3) 0px,
-        rgba(0,0,0,0.3) 2px,
+        rgba(0,0,0,0.9) 0px,
+        rgba(0,0,0,0.9) 2px,
         transparent 2px,
         transparent 4px);
     mix-blend-mode: multiply;
-    opacity: 0.5;
+    opacity: 0.1;
 }
 
 @keyframes crtFlicker {


### PR DESCRIPTION
## Summary
- set dark scanline lines and reduce overlay opacity

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_687f61ab9e08832cb473382b93e22c21