### PR TITLE
Reduce decorative avatar size

### DIFF
--- a/style.css
+++ b/style.css
@@ -746,10 +746,10 @@ br.tablet-break {
     position: fixed;
     bottom: 0;
     right: 0;
-    width: 40%;
-    max-width: 600px;
+    width: 30%;
+    max-width: 450px;
     height: auto;
-    pointer-events: auto;
+    pointer-events: none;
     z-index: 102;
     opacity: 0;
     display: none;
@@ -777,8 +777,8 @@ br.tablet-break {
 
 @media (min-width: 601px) and (max-width: 1024px) {
     #about-decor {
-        width: 55%;
-        max-width: 700px;
+        width: 40%;
+        max-width: 550px;
     }
 }
 


### PR DESCRIPTION
## Summary
- resize the decorative avatar image so it doesn't block gallery thumbnails

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687f632c2afc832c9f7028ee1523e846