### PR TITLE
Add active style to network links

### DIFF
--- a/style.css
+++ b/style.css
@@ -936,6 +936,12 @@ br.tablet-break {
     margin: 0;
 }
 
+/* Highlight network link buttons when pressed */
+.network-links .profile-link-btn:active {
+    background-color: #bcdfff;
+    color: #000;
+}
+
 #network-link .network-link-content {
     margin-left: auto;
     margin-right: auto;


### PR DESCRIPTION
## Summary
- highlight network link buttons in light blue when pressed

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687f6a61f0e0832c825cb16d29d02513