### PR TITLE
Add visibility-aware bubble animation

### DIFF
--- a/script.js
+++ b/script.js
@@ -303,6 +303,8 @@
             if (!canvas || !canvas.getContext) return;
             const ctx = canvas.getContext('2d');
             let width, height;
+            let running = true;
+            let rafId;
 
     function resize() {
         width = canvas.width = window.innerWidth;
@@ -333,6 +335,7 @@
     }
 
     function draw() {
+        if (!running) return;
         ctx.clearRect(0, 0, width, height);
         for (let i = 0; i < bubbleCount; i++) {
             ys[i] -= speeds[i];
@@ -355,11 +358,21 @@
             ctx.fill();
             ctx.restore();
         }
-        requestAnimationFrame(draw);
+        rafId = requestAnimationFrame(draw);
     }
-    draw();
+    rafId = requestAnimationFrame(draw);
+
+    document.addEventListener('visibilitychange', () => {
+        if (document.hidden) {
+            running = false;
+            if (rafId) cancelAnimationFrame(rafId);
+        } else if (!running) {
+            running = true;
+            rafId = requestAnimationFrame(draw);
         }
-    };
+    });
+    }
+};   
 
     const LazyLoadArtwork = {
         init() {


### PR DESCRIPTION
## Summary
- optimize the bubble canvas animation by pausing it when the tab is hidden

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687f7c7a0a44832c8ddf98bdec3b2a85