### PR TITLE
Add desktop-only right click block

### DIFF
--- a/script.js
+++ b/script.js
@@ -539,6 +539,18 @@
         }
     };
 
+    const RightClickBlocker = {
+        init() {
+            const desktop = window.matchMedia('(hover: hover) and (pointer: fine)').matches;
+            if (!desktop) return;
+            document.addEventListener('contextmenu', e => {
+                if (e.target.closest('img')) {
+                    e.preventDefault();
+                }
+            });
+        }
+    };
+
     const App = {
         init() {
             AntiScrape.init();
@@ -549,6 +561,7 @@
             Lightbox.init();
             BubbleAnimation.init();
             ProfileToggle.init();
+            RightClickBlocker.init();
         }
     };
 


### PR DESCRIPTION
## Summary
- intercept right click on images for desktop devices

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687fa4e5bbb0832c9e4b939dfacda1f7