### PR TITLE
Add banner section to Info

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,6 +52,7 @@
     <main>
 
         <section id="info" class="content-section hidden">
+            <h2>Banner</h2>
             <img class="info-banner" src="https://yueplush-artwork.netlify.app/banner.webp" alt="Banner">
             <p class="info-instruction">Mutual links welcome! Click the box below or copy the HTML code to get it.</p>
             <pre id="banner-code-box" class="code-box">&lt;a href="https://allbubbledup.neocities.org"&gt;&lt;img src="https://yueplush-artwork.netlify.app/banner.webp" style="image-rendering:pixelated;"&gt;&lt;/a&gt;</pre>

--- a/style.css
+++ b/style.css
@@ -753,6 +753,7 @@ br.tablet-break {
     color: #fff;
     font-family: monospace;
     cursor: pointer;
+    white-space: pre-wrap;
     word-break: break-all;
     margin-left: auto;
     margin-right: auto;


### PR DESCRIPTION
## Summary
- add "Banner" heading to the Info section so the banner image and code are grouped
- allow banner HTML code to wrap while copying remains single-line

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68826c63a148832c86f148c4b4b3d5c2