### PR TITLE
Fix info banner snippet

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@
             <h2>Banner</h2>
             <img class="info-banner" src="https://yueplush-artwork.netlify.app/banner.webp" alt="Banner">
             <p class="info-instruction">Mutual links welcome! Click the box below or copy the HTML code to get it.</p>
-            <pre id="banner-code-box" class="code-box">&lt;a href="https://allbubbledup.neocities.org"&gt;&lt;img src="https://yueplush-artwork.netlify.app/banner.webp" style="image-rendering:pixelated;"&gt;&lt;/a&gt;</pre>
+            <pre id="banner-code-box" class="code-box">&lt;a href="https://yueplushart.netlify.app/"&gt;&lt;img src="https://yueplush-artwork.netlify.app/banner.webp" style="image-rendering:pixelated;"&gt;&lt;/a&gt;</pre>
             <h2>Mutual Links</h2>
             <div class="info-content">
                 <a href="https://allbubbledup.neocities.org"><img src="https://allbubbledup.neocities.org/button.png" style="image-rendering:pixelated;"></a>


### PR DESCRIPTION
## Summary
- fix the copyable HTML banner snippet to link to yueplushart.netlify.app

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68826d635c7c832ca487e318b5978f97