### PR TITLE
Fix Commission status alignment

### DIFF
--- a/index.html
+++ b/index.html
@@ -260,9 +260,9 @@
 
         <section id="commission" class="content-section hidden">
             <h2>Commission</h2>
+            <div class="commission-content">
             <h3>Commission Status</h3>
             <p>Status: closed</p>
-            <div class="commission-content">
             <p class="commission-heading">✅️ Base Menu (Full Color)</p>
             <p>▶ $25 – Headshot (Icon, face only)</p>
             <p>▶ $45 – Bust-up (Upper body)</p>


### PR DESCRIPTION
## Summary
- move Commission Status heading and text inside the commission-content container for consistent padding

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688335349594832caacef9fcc9ad7b9c