### PR TITLE
Add Afterdark link

### DIFF
--- a/index.html
+++ b/index.html
@@ -311,6 +311,7 @@
                 <ul class="network-links">
                     <li><a class="profile-link-btn" href="https://www.furaffinity.net/user/yueplush" target="_blank" rel="noopener noreferrer">Fur Affinity</a></li>
                     <li><a class="profile-link-btn" href="https://www.deviantart.com/yueplushart" target="_blank" rel="noopener noreferrer">Deviant Art</a></li>
+                    <li><a class="profile-link-btn" href="https://afterdark.art/user/yueplushart" target="_blank" rel="noopener noreferrer">Afterdark.art</a></li>
                 </ul>
 
                 <p class="network-heading">✅️SNS</p>


### PR DESCRIPTION
## Summary
- add a button link for Afterdark.art in the Art Gallery Sites list

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688346c7072c832cbef8b5e14e91e35e