### PR TITLE
Add Afterdark.art link

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,11 @@ decoded only after two normal user interactions spaced slightly apart to catch
 automated scripts. These small layers discourage automated scraping while
 keeping the site seamless for normal visitors.
 
+## Network Links
+
+### ✅️Art Gallery Sites
+
+- [Fur Affinity](https://www.furaffinity.net/user/yueplush)
+- [Deviant Art](https://www.deviantart.com/yueplushart)
+- [Afterdark.art](https://afterdark.art/user/yueplushart)
+


### PR DESCRIPTION
## Summary
- document art gallery sites in README
- include Afterdark.art link alongside other gallery links

## Testing
- `tidy -e index.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883539bd678832ca5bd6f347373b79b